### PR TITLE
## 🔧 Fix: Type-only import for `ReactNode` in `AuthContext`

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect } from 'react';
+import type { ReactNode } from 'react';
 
 interface User {
   id: string;
@@ -31,7 +32,7 @@ interface AuthProviderProps {
   children: ReactNode;
 }
 
-export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+export function AuthProvider({ children }: AuthProviderProps) {
   const [user, setUser] = useState<User | null>(null);
   const [token, setToken] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -72,4 +73,4 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
-};
+}


### PR DESCRIPTION
### 🧩 Summary
This PR fixes a TypeScript build error caused by `verbatimModuleSyntax` enforcing type-only imports.  
`ReactNode` was imported as a value instead of a type, leading to the following error:


### 🛠 Changes Made
- Updated `src/contexts/AuthContext.tsx`:
  ```ts
  - import { createContext, useContext, ReactNode } from "react";
  + import { createContext, useContext } from "react";
  + import type { ReactNode } from "react";


Closes: #2 